### PR TITLE
!!! FEATURE: Persist more than the latest scent

### DIFF
--- a/Classes/Domain/Model/Scent.php
+++ b/Classes/Domain/Model/Scent.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\ScentMark\Domain\Model;
+
+use Neos\Flow\Annotations as Flow;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @Flow\Entity
+ * @ORM\Table(
+ *     uniqueConstraints={
+ *       @ORM\UniqueConstraint(name="unique_values",columns={"value"}),
+ *     },
+ *     indexes={
+ *       @ORM\Index(name="index_values",columns={"value"}),
+ *     }
+ *  )
+ */
+class Scent
+{
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @var \DateTime
+     */
+    protected $dateTime;
+
+    public function __construct()
+    {
+        $this->dateTime = new \DateTime();
+        $this->value = '';
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    public function getDateTime(): \DateTime
+    {
+        return $this->dateTime;
+    }
+
+    public function setDateTime(\DateTime $dateTime): void
+    {
+        $this->dateTime = $dateTime;
+    }
+}

--- a/Classes/Domain/Repository/ScentRepository.php
+++ b/Classes/Domain/Repository/ScentRepository.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Sitegeist\ScentMark\Domain\Repository;
+
+use Neos\Flow\Persistence\QueryInterface;
+use Neos\Flow\Persistence\Repository;
+use Neos\Flow\Annotations as Flow;
+use Sitegeist\ScentMark\Domain\Model\Scent;
+
+#[Flow\Scope('singleton')]
+class ScentRepository extends Repository
+{
+    /**
+     * @var array
+     */
+    protected $defaultOrderings = [
+        'dateTime' => QueryInterface::ORDER_DESCENDING
+    ];
+
+    public function removeByAge(int $keep): int
+    {
+        $outdatedScentsQuery = $this->findAll();
+        $countRemoved = 0;
+        $number = 0;
+        foreach ($outdatedScentsQuery as $scent) {
+            $number ++;
+            if ($number > $keep) {
+                $this->remove($scent);
+                $countRemoved++;
+            }
+        }
+        return $countRemoved;
+    }
+}

--- a/Configuration/Caches.yaml
+++ b/Configuration/Caches.yaml
@@ -1,6 +1,0 @@
-Sitegeist_ScentMark_ScentCache:
-  persistent: true
-  frontend: Neos\Cache\Frontend\StringFrontend
-  backend: Neos\Cache\Backend\FileBackend
-  backendOptions:
-    defaultLifetime: 0

--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,9 +1,0 @@
-Sitegeist\ScentMark\Command\ScentMarkCommandController:
-  properties:
-    scentMarkCache:
-      object:
-        factoryObjectName: Neos\Flow\Cache\CacheManager
-        factoryMethodName: getCache
-        arguments:
-          1:
-            value: Sitegeist_ScentMark_ScentCache

--- a/Migrations/Mysql/Version20240513113912.php
+++ b/Migrations/Mysql/Version20240513113912.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240513113912 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('CREATE TABLE sitegeist_scentmark_domain_model_scent (persistence_object_identifier VARCHAR(40) NOT NULL, value VARCHAR(255) NOT NULL, PRIMARY KEY(persistence_object_identifier)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('DROP TABLE sitegeist_scentmark_domain_model_scent');
+    }
+}

--- a/Migrations/Mysql/Version20240513115016.php
+++ b/Migrations/Mysql/Version20240513115016.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240513115016 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_67996EDC1D775834 ON sitegeist_scentmark_domain_model_scent (value)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('DROP INDEX UNIQ_67996EDC1D775834 ON sitegeist_scentmark_domain_model_scent');
+    }
+}

--- a/Migrations/Mysql/Version20240513120214.php
+++ b/Migrations/Mysql/Version20240513120214.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\Flow\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240513120214 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('ALTER TABLE sitegeist_scentmark_domain_model_scent ADD datetime DATETIME NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql");
+        $this->addSql('ALTER TABLE sitegeist_scentmark_domain_model_scent DROP datetime');
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,28 +1,22 @@
 # Sitegeist.ScentMark
 
 Mark and Sniff on Neos via CLI. This can help to optimize cache flushing in Cluster Environments with a green / blue 
-caching or publishing setup wehere certain tasks like cache flushing or publishing of static resources shall only be
-excuted on the first container of an newly deployed app version. 
+caching or publishing setup where certain tasks like cache flushing or publishing of static resources shall only be
+excuted on the first container of a newly deployed app version. 
 
 ## Usage
 
 The package contains two cli commands:
 
-- `./flow scentmark:mark __mark__` Store the given scent in the ScentCache 
+- `./flow scentmark:mark __mark__` Store the given scent
 
 - `./flow scentmark:sniff __mark__` Compare the cached scent with the stored value and return an error code if both do not match.
- 
+
+- `./flow scentmark:cleanup --keep 10` Remove old scents but keep the specified number of newest scents.
+
 ### Example  
 
-1. Configure ScentCache to be shared across containers.
-
-Caches.yaml
-```yaml
-Sitegeist_ScentMark_ScentCache:
-  backend: 'Neos\Cache\Backend\RedisBackend'
-```
-
-2. Adjust the container spinup script
+1. Adjust the container spinup script
 
 start.sh:   
 ```bash
@@ -41,12 +35,13 @@ if [ $? -ne 0 ]; then
 fi
 ```
 
-3. Configure flow to switch with every cache between Green / Blue caching environment
-4. Ensure the current APP_VERSION is available in the containers
+2. Configure flow to switch with every cache between Green / Blue caching environment
+3. Ensure the current APP_VERSION is available in the containers
 
 ### Authors & Sponsors
 
 * Martin Ficzel - ficzel@sitegeist.de
+* Melanie Wüst - wuest@sitegeist.de
 
 *The development and the public-releases of this package is generously sponsored
 by our employer http://www.sitegeist.de.*

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "name": "sitegeist/scentmark",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/flow": "~5.3 || ~6.0 || ~7.0 || ~8.0 || dev-master"
+        "php": ">= 8.1",
+        "neos/flow": "~8.3 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Store the scents in the database to be able to detect more than one latest scent. This should help in scenarios when older pods of a release are starting by the autoscaler while a new version is already beeing deployed.

In addition the `./flow scentmark:cleanup --keep 10` command is added to cleanup the table of scents.